### PR TITLE
Improvements to Dhrake

### DIFF
--- a/DhrakeInit.java
+++ b/DhrakeInit.java
@@ -73,7 +73,7 @@ public class DhrakeInit extends GhidraScript {
 	}
 
 	private long getConstantCallArgument(Function caller, Address addr, int index) throws IllegalStateException {
-		// This is a very reliable and slow fallback to determine the value of a constant argument 
+		// This is a very reliable and slow fallback to determine the value of a constant argument
 		// to a function call at a given address within a given function.
 		monitor.setMessage("obtaining decompiler interface");
 		DecompInterface decompInterface = new DecompInterface();
@@ -211,7 +211,6 @@ public class DhrakeInit extends GhidraScript {
 
 
 		try (BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(idc));  Scanner sc = new Scanner(inputStream, StandardCharsets.UTF_8)) {
-
 			//count lines
 			while (sc.hasNextLine()) {
 				sc.nextLine();
@@ -222,9 +221,14 @@ public class DhrakeInit extends GhidraScript {
 			this.logMsg("file not found: %s", idc.toPath());
 			return false;
 		}
+
 		try (BufferedInputStream inputStream  = new BufferedInputStream(new FileInputStream(idc));  Scanner sc = new Scanner(inputStream, StandardCharsets.UTF_8)) {
+            monitor.setMessage("Processing IDC file");
+            logMsg(String.format("Processing IDC file %s", idc.toPath()));
 
 			while (sc.hasNextLine()) {
+                if (monitor.isCancelled()) break;
+
 				String line = sc.nextLine();
 
 				monitor.setProgress(progress++);

--- a/DhrakeInit.java
+++ b/DhrakeInit.java
@@ -70,7 +70,7 @@ public class DhrakeInit extends GhidraScript {
 		}
 	}
 
-	private void logMsg(String message, Object... args){
+	private void logMsg(String message, Object... args) {
 		this.println(String.format("[Dhrake] %s", String.format(message, args)));
 	}
 

--- a/DhrakeInit.java
+++ b/DhrakeInit.java
@@ -1,5 +1,5 @@
-//Uses metadata from an IDR generated IDC script to rename symbols
-//and fix certain calls in Delphi programs
+// Uses metadata from an IDR-generated IDC script to rename symbols
+// and fix certain calls in Delphi programs
 //@category Delphi
 //@author Jesko Huettenhain
 
@@ -200,18 +200,18 @@ public class DhrakeInit extends GhidraScript {
 		int progress = 0;
 		int linecount = 0;
 
-		monitor.setMessage("loading symbols from IDC");
+		monitor.setMessage("Loading symbols from IDC");
 
 		try {
 			idc = this.askFile("IDC File Path", "Load an IDC file");
 		} catch (CancelledException e) {
 			return false;
 		}
+
 		Pattern pattern = Pattern.compile("^\\s*MakeNameEx\\((?:0x)?([A-Fa-f0-9]+),\\s*\"([^\"]*)\",\\s*([xA-Fa-f0-9]+)\\);\\s*$");
 
-
 		try (BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(idc));  Scanner sc = new Scanner(inputStream, StandardCharsets.UTF_8)) {
-			//count lines
+			// Count lines
 			while (sc.hasNextLine()) {
 				sc.nextLine();
 				linecount++;
@@ -224,7 +224,7 @@ public class DhrakeInit extends GhidraScript {
 
 		try (BufferedInputStream inputStream  = new BufferedInputStream(new FileInputStream(idc));  Scanner sc = new Scanner(inputStream, StandardCharsets.UTF_8)) {
             monitor.setMessage("Processing IDC file");
-            logMsg(String.format("Processing IDC file %s", idc.toPath()));
+            this.logMsg("Processing IDC file %s", idc.toPath());
 
 			while (sc.hasNextLine()) {
                 if (monitor.isCancelled()) break;
@@ -233,11 +233,12 @@ public class DhrakeInit extends GhidraScript {
 
 				monitor.setProgress(progress++);
 
-				if (!line.contains("MakeNameEx"))
-					continue;
+				if (!line.contains("MakeNameEx")) continue;
+
 				Matcher match = pattern.matcher(line);
-				if (!match.matches())
-					continue;
+
+				if (!match.matches()) continue;
+
 				Integer offset = Integer.parseUnsignedInt(match.group(1), 16);
 				Address entryPoint = this.toAddr(offset);
 				String functionName = match.group(2);
@@ -246,7 +247,7 @@ public class DhrakeInit extends GhidraScript {
 					try {
 						this.renameSymbol(entryPoint, functionName);
 					} catch (InvalidInputException e) {
-						this.logMsg("renaming failed for: %s", functionName);
+						this.logMsg("Renaming failed for: %s", functionName);
 					}
 				}
 			}
@@ -258,7 +259,7 @@ public class DhrakeInit extends GhidraScript {
 	}
 	private void repairStringCompareFunctions() {
 		try {
-			monitor.setMessage("reparing known function signatures");
+			monitor.setMessage("Repairing known function signatures");
 
 			VariableStorage zfReturn = new VariableStorage(
 					currentProgram, currentProgram.getRegister("ZF"));

--- a/DhrakeInit.java
+++ b/DhrakeInit.java
@@ -197,7 +197,7 @@ public class DhrakeInit extends GhidraScript {
 
 	private boolean importSymbolsFromIDC() {
 		File idc;
-		int progress = 0;
+		long progress = 0;
 		int linecount = 0;
 
 		monitor.setMessage("Loading symbols from IDC");

--- a/DhrakeParseClass.java
+++ b/DhrakeParseClass.java
@@ -62,7 +62,7 @@ public class DhrakeParseClass extends GhidraScript {
 			try {
 				this.log("Creating class %s", className);
 				classNamespace = NamespaceUtils.convertNamespaceToClass(currentProgram.getSymbolTable()
-																					  .getOrCreateNameSpace(currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
+						.getOrCreateNameSpace(currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
 			} catch (DuplicateNameException e) {
 				this.log("Class %s already exists, stopping", className);
 			}

--- a/DhrakeParseClass.java
+++ b/DhrakeParseClass.java
@@ -6,10 +6,7 @@
 import ghidra.app.script.GhidraScript;
 import ghidra.app.util.NamespaceUtils;
 import ghidra.program.model.address.Address;
-import ghidra.program.model.data.StructureDataType;
-import ghidra.program.model.data.FunctionDefinitionDataType;
-import ghidra.program.model.data.DataTypeConflictHandler;
-import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.*;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.GhidraClass;
 import ghidra.program.model.mem.MemoryAccessException;
@@ -35,9 +32,9 @@ public class DhrakeParseClass extends GhidraScript {
 		this.println(String.format("[Dhrake] %s", message));
 	}
 
-    private void log(String message, Object... args) {
-        this.println(String.format("[Dhrake] %s", String.format(message, args)));
-    }
+	private void log(String message, Object... args) {
+		this.println(String.format("[Dhrake] %s", String.format(message, args)));
+	}
 
 	@Override
 	protected void run() throws Exception {
@@ -45,6 +42,8 @@ public class DhrakeParseClass extends GhidraScript {
 		Address nameAddress = this.toAddr(this.getInt(currentAddress.add(32)));
 
 		try {
+			this.clearListing(nameAddress, nameAddress.add(1));
+			this.createData(nameAddress, PascalString255DataType.dataType);
 			className = new String(this.getBytes(nameAddress.add(1), this.getByte(nameAddress)));
 		} catch (MemoryAccessException e) {
 			this.popup("Unfortunately, we got a memory access error trying to even read the class name. " +

--- a/DhrakeParseClass.java
+++ b/DhrakeParseClass.java
@@ -6,14 +6,15 @@
 import ghidra.app.script.GhidraScript;
 import ghidra.app.util.NamespaceUtils;
 import ghidra.program.model.address.Address;
-import ghidra.program.model.data.DataType;
-import ghidra.program.model.data.DataTypeConflictHandler;
-import ghidra.program.model.data.FunctionDefinitionDataType;
 import ghidra.program.model.data.StructureDataType;
+import ghidra.program.model.data.FunctionDefinitionDataType;
+import ghidra.program.model.data.DataTypeConflictHandler;
+import ghidra.program.model.data.DataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.GhidraClass;
 import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.program.model.symbol.SourceType;
+import ghidra.util.exception.DuplicateNameException;
 
 public class DhrakeParseClass extends GhidraScript {
 
@@ -40,59 +41,66 @@ public class DhrakeParseClass extends GhidraScript {
 
 	@Override
 	protected void run() throws Exception {
-		String className = null;
+		String  className   = null;
 		Address nameAddress = this.toAddr(this.getInt(currentAddress.add(32)));
 
 		try {
 			className = new String(this.getBytes(nameAddress.add(1), this.getByte(nameAddress)));
 		} catch (MemoryAccessException e) {
 			this.popup("Unfortunately, we got a memory access error trying to even read the class name. " +
-							"Either you executed this at the wrong address or the class metadata layout is " +
-							"unknown. If you can figure out how to identify this Delphi compiler and how it " +
-							"stores class metadata, that'd be Bill-Lumbergh-Level great.");
+							   "Either you executed this at the wrong address or the class metadata layout is " +
+							   "unknown. If you can figure out how to identify this Delphi compiler and how it " +
+							   "stores class metadata, that'd be Bill-Lumbergh-Level great.");
 			return;
 		}
 
-		assert className.startsWith("T");
-		this.log(className);
-		this.log(String.format("creating class %s", className));
+		// Create Data Structures + Methods
+		if (className.toUpperCase().startsWith("T") || className.toUpperCase().startsWith("E")) {
+			this.log(className);
 
-		GhidraClass classNamespace = NamespaceUtils.convertNamespaceToClass(
-					currentProgram.getSymbolTable().createNameSpace(
-							currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
+			GhidraClass classNamespace = null;
 
-		StructureDataType base = new StructureDataType(className, 0);
-		StructureDataType vtbl = new StructureDataType(className + "VT", 0);
-
-		long vt = this.getInt(currentAddress);
-
-		for (long tooDamnHigh = vt + 4 * 100; vt < tooDamnHigh; vt += 4) {
 			try {
-				long offset = this.getInt(this.toAddr(vt));
-				String name = null;
-				Address entryPoint = this.toAddr(offset);
-				Function function = this.getFunctionAt(entryPoint);
-				if (function == null) {
-					name = this.getSymbolAt(entryPoint).toString();
-					if (name == null) {
-						name = String.format("FUN_%08X", offset);
+				this.log("Creating class %s", className);
+				classNamespace = NamespaceUtils.convertNamespaceToClass(currentProgram.getSymbolTable()
+																					  .getOrCreateNameSpace(currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
+			} catch (DuplicateNameException e) {
+				this.log("Class %s already exists, stopping", className);
+			}
+
+			StructureDataType base = new StructureDataType(className, 0);
+			StructureDataType vtbl = new StructureDataType(className + "VT", 0);
+
+			long vt = this.getInt(currentAddress);
+
+			if (classNamespace != null) {
+				for (long tooDamnHigh = vt + 4 * 100; vt < tooDamnHigh; vt += 4) {
+					try {
+						long     offset     = this.getInt(this.toAddr(vt));
+						String   name       = null;
+						Address  entryPoint = this.toAddr(offset);
+						Function function   = this.getFunctionAt(entryPoint);
+						if (function == null) {
+							name = this.getSymbolAt(entryPoint).toString();
+							if (name == null) {
+								name = String.format("FUN_%08X", offset);
+							}
+							this.log(String.format("defining function at 0x%08X, name %s", offset, name));
+							function = this.createFunction(entryPoint, name);
+						}
+						if (function == null) break;
+						function.setParentNamespace(classNamespace);
+						name = function.getName();
+						this.log(String.format("adding function %s::%s", className, name));
+						vtbl.add(this.addFnType(function), 4, name, "");
+					} catch (Exception e) {
+						break;
 					}
-					this.log(String.format("defining function at 0x%08X, name %s", offset, name));
-					function = this.createFunction(entryPoint, name);
 				}
-				if (function == null)
-					break;
-				function.setParentNamespace(classNamespace);
-				name = function.getName();
-				this.log(String.format("adding function %s::%s", className, name));
-				vtbl.add(this.addFnType(function), 4, name, "");
-			} catch (Exception e) {
-				break;
+
+				base.add(this.getCurrentProgram().getDataTypeManager().getPointer(this.putType(vtbl)), "vt", "Virtual Function Table");
+				this.putType(base);
 			}
 		}
-
-		base.add(this.getCurrentProgram().getDataTypeManager().getPointer(this.putType(vtbl)),
-				 "vt", "Virtual Function Table");
-		this.putType(base);
 	}
 }

--- a/DhrakeParseClass.java
+++ b/DhrakeParseClass.java
@@ -6,10 +6,10 @@
 import ghidra.app.script.GhidraScript;
 import ghidra.app.util.NamespaceUtils;
 import ghidra.program.model.address.Address;
-import ghidra.program.model.data.StructureDataType;
-import ghidra.program.model.data.FunctionDefinitionDataType;
-import ghidra.program.model.data.DataTypeConflictHandler;
 import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataTypeConflictHandler;
+import ghidra.program.model.data.FunctionDefinitionDataType;
+import ghidra.program.model.data.StructureDataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.GhidraClass;
 import ghidra.program.model.mem.MemoryAccessException;
@@ -34,30 +34,38 @@ public class DhrakeParseClass extends GhidraScript {
 		this.println(String.format("[Dhrake] %s", message));
 	}
 
+    private void log(String message, Object... args) {
+        this.println(String.format("[Dhrake] %s", String.format(message, args)));
+    }
+
 	@Override
 	protected void run() throws Exception {
 		String className = null;
 		Address nameAddress = this.toAddr(this.getInt(currentAddress.add(32)));
+
 		try {
 			className = new String(this.getBytes(nameAddress.add(1), this.getByte(nameAddress)));
 		} catch (MemoryAccessException e) {
-			this.popup(
-					"Unfortunately, we got a memory access error trying to even read the class name. "	+
-							"Either you executed this at the wrong address or the class metadata layout is "	+
-							"unknown. If you can figure out how to identify this Delphi compiler and how it "	+
-							"stores class metadata, that'd be Bill-Lumbergh-Level great."
-			);
+			this.popup("Unfortunately, we got a memory access error trying to even read the class name. " +
+							"Either you executed this at the wrong address or the class metadata layout is " +
+							"unknown. If you can figure out how to identify this Delphi compiler and how it " +
+							"stores class metadata, that'd be Bill-Lumbergh-Level great.");
 			return;
 		}
+
 		assert className.startsWith("T");
 		this.log(className);
 		this.log(String.format("creating class %s", className));
+
 		GhidraClass classNamespace = NamespaceUtils.convertNamespaceToClass(
-				currentProgram.getSymbolTable().createNameSpace(
-						currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
+					currentProgram.getSymbolTable().createNameSpace(
+							currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
+
 		StructureDataType base = new StructureDataType(className, 0);
 		StructureDataType vtbl = new StructureDataType(className + "VT", 0);
+
 		long vt = this.getInt(currentAddress);
+
 		for (long tooDamnHigh = vt + 4 * 100; vt < tooDamnHigh; vt += 4) {
 			try {
 				long offset = this.getInt(this.toAddr(vt));
@@ -82,9 +90,9 @@ public class DhrakeParseClass extends GhidraScript {
 				break;
 			}
 		}
+
 		base.add(this.getCurrentProgram().getDataTypeManager().getPointer(this.putType(vtbl)),
 				 "vt", "Virtual Function Table");
 		this.putType(base);
-
 	}
 }

--- a/DhrakeParseClass.java
+++ b/DhrakeParseClass.java
@@ -29,7 +29,7 @@ public class DhrakeParseClass extends GhidraScript {
 		FunctionDefinitionDataType ft = new FunctionDefinitionDataType(fn, false);
 		return this.putType(ft, DataTypeConflictHandler.KEEP_HANDLER);
 	}
-	
+
 	protected void log(String message) {
 		this.println(String.format("[Dhrake] %s", message));
 	}
@@ -38,14 +38,14 @@ public class DhrakeParseClass extends GhidraScript {
 	protected void run() throws Exception {
 		String className = null;
 		Address nameAddress = this.toAddr(this.getInt(currentAddress.add(32)));
-		try {	
+		try {
 			className = new String(this.getBytes(nameAddress.add(1), this.getByte(nameAddress)));
 		} catch (MemoryAccessException e) {
 			this.popup(
-				"Unfortunately, we got a memory access error trying to even read the class name. "	+
-				"Either you executed this at the wrong address or the class metadata layout is "	+
-				"unknown. If you can figure out how to identify this Delphi compiler and how it "	+
-				"stores class metadata, that'd be Bill-Lumbergh-Level great."
+					"Unfortunately, we got a memory access error trying to even read the class name. "	+
+							"Either you executed this at the wrong address or the class metadata layout is "	+
+							"unknown. If you can figure out how to identify this Delphi compiler and how it "	+
+							"stores class metadata, that'd be Bill-Lumbergh-Level great."
 			);
 			return;
 		}
@@ -53,8 +53,8 @@ public class DhrakeParseClass extends GhidraScript {
 		this.log(className);
 		this.log(String.format("creating class %s", className));
 		GhidraClass classNamespace = NamespaceUtils.convertNamespaceToClass(
-			currentProgram.getSymbolTable().createNameSpace(
-				currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
+				currentProgram.getSymbolTable().createNameSpace(
+						currentProgram.getGlobalNamespace(), className, SourceType.USER_DEFINED));
 		StructureDataType base = new StructureDataType(className, 0);
 		StructureDataType vtbl = new StructureDataType(className + "VT", 0);
 		long vt = this.getInt(currentAddress);
@@ -83,7 +83,7 @@ public class DhrakeParseClass extends GhidraScript {
 			}
 		}
 		base.add(this.getCurrentProgram().getDataTypeManager().getPointer(this.putType(vtbl)),
-			"vt", "Virtual Function Table");
+				 "vt", "Virtual Function Table");
 		this.putType(base);
 
 	}


### PR DESCRIPTION
Sorry for the long delays! So, changes in this PR include:

1. Ability to cancel IDC processing while running (wasn't possible before).
2. Process Pascal strings found inside the IDC. Unicode parsing is disabled for the time being due to an oddity I discovered (I think an issue with IDR).
3. Handle the Exception where the user may recreate an existing Class (re: DuplicateNameException).
4. Applied some formatting and fixed minor typos.

There's a lot more changes I want to bring in, which leads me to ask...

@huettenhain: I believe creating separate PRs for the remaining changes I have planned will be ideal, as some of my modifications may not necessarily align the project's goals. Examples include:

1. `DhrakeInit`: Give the user the ability to disable (skip) the _line counting_ portion in PR #5 because of the sheer (waste) of time it takes to process IDCs that are huge to begin with. It takes more time to count the number of lines for the purpose of showing a progress bar in Ghidra than the time it takes to process a binary.
2. `DhrakeParseClass`: Instead of dumping newly created DataTypes in `/root`, I suggest creating a hierarchy like so: `/root/Dhrake/TObject/Object`. What do you think? (can be user adjustable of course) ![image](https://github.com/huettenhain/dhrake/assets/1860472/50fb82d4-4478-4a9c-bdae-e0589e8e39c8).
3. Lastly, do you absolutely require source to be indented with TAB characters? I'm more of a 4-spaces type of guy. 😅 